### PR TITLE
fix: Add exclusion for formspree.io in link checker to prevent false …

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,5 +21,5 @@ jobs:
       - name: Check for broken links
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --no-progress --exclude 'mailto:.*' index.html
+          args: --no-progress --exclude 'mailto:.*' --exclude 'formspree.io' index.html
           fail: true


### PR DESCRIPTION
…positives